### PR TITLE
Add brightness detection feature

### DIFF
--- a/src/main/java/net/jiyuu_ni/LiFXCameraBacklight/App.java
+++ b/src/main/java/net/jiyuu_ni/LiFXCameraBacklight/App.java
@@ -29,10 +29,10 @@ import com.github.sarxos.webcam.WebcamPanel;
 import com.github.sarxos.webcam.WebcamResolution;
 import com.stuntguy3000.lifxlansdk.handler.PacketHandler;
 import com.stuntguy3000.lifxlansdk.helper.MultiZoneHelper;
-import com.stuntguy3000.lifxlansdk.object.product.Device;
 import com.stuntguy3000.lifxlansdk.object.product.MultiZone;
 
 import ch.qos.logback.classic.LoggerContext;
+import net.jiyuu_ni.LiFXCameraBacklight.config.BrightnessDetection;
 import net.jiyuu_ni.LiFXCameraBacklight.config.ConfigFile;
 import net.jiyuu_ni.LiFXCameraBacklight.config.ScreenLayout;
 import net.jiyuu_ni.LiFXCameraBacklight.config.ScreenLayout.LayoutPosition;
@@ -58,6 +58,7 @@ public class App
 	private static final String DEFAULT_MAC_ADDRESS = "00-NO-TR-EA-L0-00";
 	private static final ObjectMapper jsonMapper = new ObjectMapper();
 	private static final Logger logger = LoggerFactory.getLogger(App.class);
+	private static final App currentInstance = new App();
 	
 	// TODO: Watch / handle camera connection / disconnection
 	// TODO: Separate logic so less is being done in "main"
@@ -200,14 +201,15 @@ public class App
 						"names and LiFX information (already detected above) to " +
 						"fill out a valid configuration file. Once configured, " +
 						"restart this program.",
-						webcamList.get(0).getName());
+						webcamList.get(0).getName()); 
 				
 				// Make sure internal config is rewritten to be consistent
 				//    with the "using only default webcam" and "first detected"
 				//    LiFX device or fake values" approach
 				currentConfig = new ConfigFile(Path.of(""), NETWORK_BROADCAST_ADDRESS,
 						Collections.singletonList(webcamList.get(0).getName()),
-						Collections.singletonList(tempScreenLayout), false);
+						Collections.singletonList(tempScreenLayout),
+						BrightnessDetection.createDefaultConfig(), false);
 				
 				// Save the default config, which if at all possible now
 				//    contains some real cameras and devices detected on
@@ -246,7 +248,7 @@ public class App
     {
     	logger.trace("Entering main");
     	
-    	App currentInstance = new App();
+    	//App currentInstance = new App();
   	
     	for(WebcamMotionDetector detector : detectorList) {
     		logger.info("Starting motion detector for {}",

--- a/src/main/java/net/jiyuu_ni/LiFXCameraBacklight/config/BrightnessDetection.java
+++ b/src/main/java/net/jiyuu_ni/LiFXCameraBacklight/config/BrightnessDetection.java
@@ -1,0 +1,37 @@
+package net.jiyuu_ni.LiFXCameraBacklight.config;
+
+import java.beans.ConstructorProperties;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class BrightnessDetection {
+	// Should webcam attempt to mitigate motion detection with an additional
+	//    check for images that are not bright enough to reliably indicate motion
+	private final boolean ENABLED;
+	
+	// If the feature should be enabled, what threshold for brightness (between
+	//    0 and 1) should be considered "not bright enough"?
+	private final float THRESHOLD;
+	
+	@ConstructorProperties({"enabled", "threshold"})
+	public BrightnessDetection(boolean enabled, float threshold) {
+		this.ENABLED = enabled;
+		this.THRESHOLD = threshold;
+	}
+
+	@JsonProperty("enabled")
+	public boolean isEnabled() {
+		return ENABLED;
+	}
+
+	@JsonProperty("threshold")
+	public float getThreshold() {
+		return THRESHOLD;
+	}
+	
+	@JsonIgnore
+	public static BrightnessDetection createDefaultConfig() {
+		return new BrightnessDetection(true, 0.1f);
+	}
+}

--- a/src/main/java/net/jiyuu_ni/LiFXCameraBacklight/config/ConfigFile.java
+++ b/src/main/java/net/jiyuu_ni/LiFXCameraBacklight/config/ConfigFile.java
@@ -23,18 +23,23 @@ public class ConfigFile {
 	// List of bindings between a piece of the screen and a light
 	private final List<ScreenLayout> LAYOUT_LIST;
 	
+	// Brightness detection settings
+	private final BrightnessDetection BRIGHTNESS;
+	
 	// Whether to show a preview GUI of the webcam(s)
 	private final boolean SHOW_GUI;
 	
 	@ConstructorProperties({"log_path", "broadcast_ip_address", "webcam_list",
-		"layout_list", "show_gui"})
+		"layout_list", "brightness_detection", "show_gui"})
 	public ConfigFile(Path logPath, String ipAddress, List<String> webcamList,
-			List<ScreenLayout> layoutList, boolean showGui) {
+			List<ScreenLayout> layoutList, BrightnessDetection brightness,
+			boolean showGui) {
 		super();
 		this.LOG_FILE_PATH = logPath;
 		this.NETWORK_BROADCAST_ADDRESS = ipAddress;
 		this.WEBCAM_LIST = webcamList;
 		this.LAYOUT_LIST = layoutList;
+		this.BRIGHTNESS = brightness;
 		this.SHOW_GUI = showGui;
 	}
 	
@@ -56,6 +61,11 @@ public class ConfigFile {
 	@JsonProperty("layout_list")
 	public List<ScreenLayout> getLayoutList() {
 		return LAYOUT_LIST;
+	}
+	
+	@JsonProperty("brightness_detection")
+	public BrightnessDetection getBrightness() {
+		return BRIGHTNESS;
 	}
 
 	@JsonProperty("show_gui")
@@ -86,8 +96,10 @@ public class ConfigFile {
 			tempLayoutList.add(tempLayout);
 		}
 		
+		BrightnessDetection tempBright = new BrightnessDetection(false, 0.1f);
+		
 		return new ConfigFile(tempPath, ipAddress, tempWebcamList,
-				tempLayoutList, false);
+				tempLayoutList, tempBright, false);
 	}
 
 	@Override
@@ -110,6 +122,12 @@ public class ConfigFile {
 			sb.append("  * ");
 			sb.append(layout.toString());
 		}
+		
+		sb.append("\nBrightness Detection:");
+		sb.append("  * Enabled: ");
+		sb.append(BRIGHTNESS.isEnabled());
+		sb.append("\n  * Threshold: ");
+		sb.append(BRIGHTNESS.getThreshold());
 		
 		sb.append("\nShow GUI: ");
 		sb.append(SHOW_GUI);

--- a/src/main/java/net/jiyuu_ni/LiFXCameraBacklight/util/ColorUtil.java
+++ b/src/main/java/net/jiyuu_ni/LiFXCameraBacklight/util/ColorUtil.java
@@ -12,9 +12,56 @@ import net.jiyuu_ni.LiFXCameraBacklight.config.ScreenLayout.LayoutPosition;
 public class ColorUtil {
 	private static final Logger logger = LoggerFactory.getLogger(ColorUtil.class);
 	
-	/*
-	 * Get average colors from specified zone of a BufferedImage
+	/**
+	 * Get average color, in RGB values, from a specified portion of an image.
+	 * @param bi
+	 * @param rows
+	 * @param columns
+	 * @param sampleSizeX
+	 * @param sampleSizeY
+	 * @return
+	 */
+	private static java.awt.Color getAverageColor(BufferedImage bi, int xMin,
+			int xMax, int yMin, int yMax) {
+		logger.trace("Entering getAverageColor");
+		
+		long sumr = 0, sumg = 0, sumb = 0;
+		
+		// With the coordinates established, capture all relevant pixels into
+		//    a matrix whose every element contains all three of R, G, and B values
+		for(int x = xMin; x < xMax; x++) {
+			for(int y = yMin; y < yMax; y++) {
+				java.awt.Color pixel = new java.awt.Color(bi.getRGB(x, y));
+                sumr += pixel.getRed();
+                sumg += pixel.getGreen();
+                sumb += pixel.getBlue();
+			}
+		}
+		
+		// Total number of elements in the resulting matrix is:
+		//    int[xMax - xMin][yMax - yMin]
+		int dim = (xMax - xMin) * (yMax - yMin);
+		
+		logger.trace("Exiting getAverageColor");
+		
+		// Mean average of a matrix is (sum of elements) / (number of elements)
+		//    Since every element has all three of R, G, and B it's possible to
+		//    divide each color's sum by the total dimension of the matrix
+		return new java.awt.Color(Math.round(sumr / dim), Math.round(sumg / dim),
+				Math.round(sumb / dim));
+	}
+	
+	/**
+	 * Get average color, in RGB value, from specified zone of a BufferedImage
+	 * given a specific LayoutPosition
 	 * Based on: https://stackoverflow.com/a/71065493
+	 * @param bi
+	 * @param position
+	 * @param xMin
+	 * @param yMin
+	 * @param sampleSizeX
+	 * @param sampleSizeY
+	 * @return
 	 */
 	public static java.awt.Color getAverageColor(BufferedImage bi,
 			LayoutPosition position, int xMin, int yMin, int sampleSizeX,
@@ -61,30 +108,9 @@ public class ColorUtil {
 			}
 		}
 		
-		long sumr = 0, sumg = 0, sumb = 0;
-		
-		// With the coordinates established, capture all relevant pixels into
-		//    a matrix whose every element contains all three of R, G, and B values
-		for(int x = xMin; x < xMax; x++) {
-			for(int y = yMin; y < yMax; y++) {
-				java.awt.Color pixel = new java.awt.Color(bi.getRGB(x, y));
-                sumr += pixel.getRed();
-                sumg += pixel.getGreen();
-                sumb += pixel.getBlue();
-			}
-		}
-		
-		// Total number of elements in the resulting matrix is:
-		//    int[xMax - xMin][yMax - yMin]
-		int dim = (xMax - xMin) * (yMax - yMin);
-		
 		logger.trace("Exiting getAverageColor");
 		
-		// Mean average of a matrix is (sum of elements) / (number of elements)
-		//    Since every element has all three of R, G, and B it's possible to
-		//    divide each color's sum by the total dimension of the matrix
-		return new java.awt.Color(Math.round(sumr / dim), Math.round(sumg / dim),
-				Math.round(sumb / dim));
+		return getAverageColor(bi, xMin, xMax, yMin, yMax);
 	}
 	
 	public static Color[] getColorFromImage(BufferedImage image,
@@ -113,5 +139,64 @@ public class ColorUtil {
 		logger.trace("Exiting getColorFromImage");
 		
 		return colorArray;
+	}
+	
+	/**
+	 * Determine if an image is "too dark" based on a provided brightness
+	 * threshold (between 0.0 and 1.0).
+	 * @param image
+	 * @param threshold
+	 */
+	public static boolean isImageTooDark(BufferedImage image, float threshold) {
+		/*
+		 * This method will likely be processing full webcam frames, which can easily
+		 * be 1280 x 720 pixels or more. In order to detect "darkness" without spending
+		 * too much CPU time on processing every possible pixel, the provided image will be
+		 * split into 12 horizontal "strips". The 3rd, 6th, and 9th strips will then
+		 * be averaged in their entirety, minus 10% on the left and right ends to 
+		 * account for camera images which don't exactly match the TV screen they're
+		 * pointed at. If all three strips average at or below the
+		 * specified threshold, that should be sufficient to indicate that the
+		 * majority of the image is at or below the threshold as well.
+		 * 
+		 * All of this means that instead of processing 1280 * 720 = 921,600 pixels
+		 * we're only processing (1280 / 12 * 0.8) * (720 / 12) =  5,120 pixels.
+		 */
+		
+		logger.trace("Entering isImageTooDark");
+		
+		boolean result = false;
+		
+		float margin = 0.1f;
+		int xMin = Math.round(image.getWidth() * margin);
+		int xMax = Math.round(image.getWidth() * (1 - margin));
+		float brightness = 0f;
+		
+		for(int i = 0; i < 12; i++) {
+			// Only calculate on passes 3, 6, and 9
+			if(i % 3 == 0) {
+				int yMin = Math.round((image.getHeight() / 12) * i);
+				int yMax = Math.round(image.getHeight() / 12 * (i + 1));
+				
+				java.awt.Color tempColor = getAverageColor(image, xMin, xMax, yMin, yMax);
+				
+				float[] tempHSB = java.awt.Color.RGBtoHSB(tempColor.getRed(),
+						tempColor.getGreen(), tempColor.getBlue(), null);
+				brightness += tempHSB[2];
+			}
+		}
+		
+		// Average of the 3 brightness bands
+		float avgBrightness = brightness / 3;
+		logger.debug("Average image brightness: {}", avgBrightness);
+		
+		if(avgBrightness <= threshold) {
+			result = true;
+		}
+		
+		logger.debug("Darkness calculation result: {}", result);
+		logger.trace("Exiting isImageTooDark");
+		
+		return result;
 	}
 }


### PR DESCRIPTION
Motion events can be fired erroneously for several reason, including webcams generating artifacts in rooms that lack lighting or reflections going across a TV that is off. This brightness detection feature, if enabled, will only process motion events if the image which caused the motion event is deemed to be bright enough (via a configurable threshold) to count as reliable motion.